### PR TITLE
auto correct logger level configuration

### DIFF
--- a/lualibs/logging.lua
+++ b/lualibs/logging.lua
@@ -46,11 +46,13 @@ ERROR = "ERROR"
 -- lead the application to abort
 FATAL = "FATAL"
 
-local LEVEL = {"DEBUG", "INFO", "WARN", "ERROR", "FATAL"}
+local LEVEL = {"DEBUG", "INFO", "WARN", "ERROR", "FATAL" }
+LEVELS = {}
 local MAX_LEVELS = #LEVEL
 -- make level names to order
 for i=1,MAX_LEVELS do
 	LEVEL[LEVEL[i]] = i
+    LEVELS[LEVEL[i]] = i
 end
 
 function cleverformat(fmt, ...)

--- a/luasrc/mch/logger.lua
+++ b/luasrc/mch/logger.lua
@@ -27,6 +27,7 @@ local debug_getinfo = debug.getinfo
 local io_open       = io.open
 local os_date       = os.date
 local ngx_time      = ngx.time
+local string_upper  = string.upper
 
 logging = require("logging")
 mchutil = require("mch.util")
@@ -46,7 +47,11 @@ function get_logger(appname)
     end
     
     if log_config and type(log_config.level) == "string" then
-        level = log_config.level
+        local tmp = string_upper(log_config.level)
+        if not logging.LEVELS[tmp] then
+            tmp = 'DEBUG'
+        end
+        level = tmp
     end
 
     local log_filename = function(date)


### PR DESCRIPTION
修复在application.lua中写错logger level导致moochine初始化失败的情况
